### PR TITLE
[CIVP-19698] add MistralResponseError so caller can check response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.2.1] - 2019-11-07
+
+### Added
+- A new exception with the request to mistral attached
+
 ## [1.2.0] - 2018-12-17
 
 ### Added

--- a/lib/mistral_client/client.rb
+++ b/lib/mistral_client/client.rb
@@ -70,7 +70,7 @@ module MistralClient
       if resp.code == 404
         raise MissingObjectError, JSON.parse(resp.body)['faultstring']
       end
-      raise MistralError,
+      raise MistralResponseError.new(resp),
             "Could not perform the requested operation:\n#{resp.body}"
     end
   end

--- a/lib/mistral_client/error.rb
+++ b/lib/mistral_client/error.rb
@@ -3,4 +3,12 @@ module MistralClient
 
   class ConfigurationError < MistralError; end
   class MissingObjectError < MistralError; end
+  class MistralResponseError < MistralError
+    attr_reader :response
+
+    def initialize(response)
+      @response = response
+      super(response)
+    end
+  end
 end

--- a/lib/mistral_client/version.rb
+++ b/lib/mistral_client/version.rb
@@ -1,3 +1,3 @@
 module MistralClient
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.2.1'.freeze
 end

--- a/mistral_client.gemspec
+++ b/mistral_client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'httparty', '~> 0.15.6'
-  spec.add_development_dependency 'bundler', '~> 1.15'
+  spec.add_development_dependency 'bundler', '~> 2.0.2'
   spec.add_development_dependency 'pry', '~> 0.11.1'
   spec.add_development_dependency 'rake', '~> 12.1'
   spec.add_development_dependency 'rspec', '~> 3.6'

--- a/spec/mistral_client/client_spec.rb
+++ b/spec/mistral_client/client_spec.rb
@@ -115,10 +115,10 @@ describe MistralClient::Client do
         client.send(:check_for_error, missing_object_response)
       end.to raise_error(MistralClient::MissingObjectError, 'Invalid object')
     end
-    it 'raises MistralError on non-404 error' do
+    it 'raises MistralResponseError on non-404 error' do
       expect do
         client.send(:check_for_error, error_response)
-      end.to raise_error(MistralClient::MistralError, /problem found/)
+      end.to raise_error(MistralClient::MistralResponseError, /problem found/)
     end
   end
 end


### PR DESCRIPTION
In the event of an error looking at the http error codes or other response information could be useful for callers of the api client.